### PR TITLE
feat: add cli for overwriting task dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ chart = manager.show_improved_chart("YFB", "plan.xlsx")
 manager.show_protection_status("YFB")
 ```
 
+### Overwrite Task Dates from the Command Line
+
+Use the dedicated helper script to adjust task schedules that are already stored
+in the historical database:
+
+```bash
+python update_task_dates.py \
+  --db burnup_history.db \
+  --project "Demo Project" \
+  --task "Implement Feature" \
+  --start-date 2024-02-01 \
+  --end-date 2024-02-20
+```
+
+The command exits with status code `0` on success, `1` when the provided dates
+are invalid, and `2` if no matching task records are found.
+
 ### Data Format
 
 Your Excel/CSV file should contain the following columns:

--- a/src/burnup_manager.py
+++ b/src/burnup_manager.py
@@ -132,6 +132,23 @@ class BurnUpManager:
         else:
             print("  Can safely execute daily_update()")
 
+    def overwrite_task_dates(
+        self,
+        project_name: str,
+        task_name: str,
+        new_start_date: date,
+        new_end_date: date,
+    ) -> bool:
+        """Overwrite start and end dates for a specific task."""
+
+        print(
+            f"✏️ Overwriting dates for task '{task_name}' in project '{project_name}' "
+            f"→ {new_start_date} to {new_end_date}"
+        )
+        return self.system.overwrite_task_dates(
+            project_name, task_name, new_start_date, new_end_date
+        )
+
     # Convenience methods for year-specific operations
     def initialize_project_for_year(self, file_path: str, year: int) -> bool:
         """Initialize project for a specific year.

--- a/src/burnup_system.py
+++ b/src/burnup_system.py
@@ -263,6 +263,44 @@ class BurnUpSystem:
             print(f"❌ Daily update failed: {e}")
             return False
 
+    def overwrite_task_dates(
+        self,
+        project_name: str,
+        task_name: str,
+        new_start_date: date,
+        new_end_date: date,
+    ) -> bool:
+        """Overwrite start and end dates for a specific task in the database.
+
+        Args:
+            project_name: Name of the project containing the task
+            task_name: Name of the task to update
+            new_start_date: Updated start date
+            new_end_date: Updated end date
+
+        Returns:
+            True if any records were updated, False otherwise
+        """
+        if new_start_date > new_end_date:
+            raise ValueError("Start date cannot be later than end date")
+
+        updated_count = self.db_model.update_task_dates(
+            project_name, task_name, new_start_date, new_end_date
+        )
+
+        if updated_count == 0:
+            print(
+                "⚠️ No matching records found in the historical database "
+                f"for task '{task_name}' under project '{project_name}'"
+            )
+            return False
+
+        print(
+            f"✅ Updated {updated_count} historical records for task '{task_name}' "
+            f"in project '{project_name}'"
+        )
+        return True
+
     def create_burnup_chart(
         self,
         project_name: str,

--- a/src/database_model.py
+++ b/src/database_model.py
@@ -128,6 +128,48 @@ class DatabaseModel:
         conn.commit()
         conn.close()
 
+    def update_task_dates(
+        self,
+        project_name: str,
+        task_name: str,
+        new_start_date: date,
+        new_end_date: date,
+    ) -> int:
+        """Overwrite start and end dates for a specific task.
+
+        Args:
+            project_name: Project name that owns the task
+            task_name: Name of the task to update
+            new_start_date: Updated start date
+            new_end_date: Updated end date
+
+        Returns:
+            Number of records affected by the update.
+        """
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute(
+            """
+            UPDATE daily_progress
+            SET start_date = ?, end_date = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE project_name = ? AND task_name = ?
+            """,
+            (
+                new_start_date.isoformat(),
+                new_end_date.isoformat(),
+                project_name,
+                task_name,
+            ),
+        )
+
+        affected_rows = cursor.rowcount
+
+        conn.commit()
+        conn.close()
+
+        return affected_rows if affected_rows is not None else 0
+
     def get_existing_record(
         self, record_date: date, project_name: str, task_name: str
     ) -> Optional[float]:

--- a/tests/test_update_task_dates_cli.py
+++ b/tests/test_update_task_dates_cli.py
@@ -1,0 +1,108 @@
+"""Tests for the standalone task date overwrite CLI."""
+
+import os
+import sqlite3
+import tempfile
+from datetime import date
+from unittest import TestCase
+
+from update_task_dates import main as cli_main
+from src.database_model import DatabaseModel
+
+
+class UpdateTaskDatesCLITest(TestCase):
+    """Ensure the CLI updates records as expected."""
+
+    def setUp(self) -> None:
+        self.temp_db = tempfile.NamedTemporaryFile(delete=False)
+        self.temp_db.close()
+        self.db_model = DatabaseModel(self.temp_db.name)
+
+        # Seed with a sample record to update during tests
+        self.db_model.insert_progress_record(
+            record_date=date(2024, 1, 15),
+            project_name="Demo Project",
+            task_name="Implement Feature",
+            assignee="Alice",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            actual_progress=0.5,
+            status="In Progress",
+            show_label="v",
+            is_backfilled=False,
+        )
+
+    def tearDown(self) -> None:
+        os.unlink(self.temp_db.name)
+
+    def test_successful_update(self) -> None:
+        """CLI should return zero and update dates when task exists."""
+
+        exit_code = cli_main(
+            [
+                "--db",
+                self.temp_db.name,
+                "--project",
+                "Demo Project",
+                "--task",
+                "Implement Feature",
+                "--start-date",
+                "2024-02-01",
+                "--end-date",
+                "2024-02-20",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+
+        conn = sqlite3.connect(self.temp_db.name)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT start_date, end_date FROM daily_progress WHERE task_name = ?",
+            ("Implement Feature",),
+        )
+        start_value, end_value = cursor.fetchone()
+        conn.close()
+
+        self.assertEqual(start_value, "2024-02-01")
+        self.assertEqual(end_value, "2024-02-20")
+
+    def test_missing_task_returns_non_zero(self) -> None:
+        """Missing tasks should return a dedicated exit code."""
+
+        exit_code = cli_main(
+            [
+                "--db",
+                self.temp_db.name,
+                "--project",
+                "Demo Project",
+                "--task",
+                "Missing Task",
+                "--start-date",
+                "2024-02-01",
+                "--end-date",
+                "2024-02-20",
+            ]
+        )
+
+        self.assertEqual(exit_code, 2)
+
+    def test_invalid_date_range(self) -> None:
+        """Start date after end date should yield error exit code."""
+
+        exit_code = cli_main(
+            [
+                "--db",
+                self.temp_db.name,
+                "--project",
+                "Demo Project",
+                "--task",
+                "Implement Feature",
+                "--start-date",
+                "2024-03-10",
+                "--end-date",
+                "2024-03-01",
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)

--- a/update_task_dates.py
+++ b/update_task_dates.py
@@ -1,0 +1,91 @@
+"""Command-line helper to overwrite task start and end dates in the burn-up database."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from typing import Iterable, Optional
+
+from src.burnup_manager import BurnUpManager
+
+
+def _parse_iso_date(value: str) -> date:
+    """Parse an ISO formatted date string (YYYY-MM-DD)."""
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"Invalid date '{value}'. Expected format YYYY-MM-DD."
+        ) from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create an argument parser for the CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Overwrite the stored start and end dates for a specific task in the "
+            "burn-up chart historical database."
+        )
+    )
+    parser.add_argument(
+        "--db",
+        default="burnup_history.db",
+        help="Path to the SQLite database file (default: burnup_history.db).",
+    )
+    parser.add_argument("--project", required=True, help="Project name that owns the task.")
+    parser.add_argument("--task", required=True, help="Task name to update.")
+    parser.add_argument(
+        "--start-date",
+        required=True,
+        type=_parse_iso_date,
+        help="New task start date in YYYY-MM-DD format.",
+    )
+    parser.add_argument(
+        "--end-date",
+        required=True,
+        type=_parse_iso_date,
+        help="New task end date in YYYY-MM-DD format.",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """Entry point for the CLI.
+
+    Args:
+        argv: Optional iterable of argument strings. When ``None`` the arguments
+            are read from ``sys.argv``.
+
+    Returns:
+        Exit status code (0 on success).
+    """
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    manager = BurnUpManager(db_path=args.db)
+
+    try:
+        updated = manager.overwrite_task_dates(
+            args.project, args.task, args.start_date, args.end_date
+        )
+    except ValueError as exc:
+        print(f"❌ {exc}")
+        return 1
+
+    if updated:
+        print(
+            "✅ Successfully updated task dates: "
+            f"{args.project} / {args.task} → {args.start_date} to {args.end_date}"
+        )
+        return 0
+
+    print(
+        "⚠️ No matching records were found in the database for the provided "
+        "project and task."
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone CLI script to overwrite stored task start and end dates
- document how to run the new helper from the command line
- cover the CLI behaviour with focused unit tests

## Testing
- `poetry run pytest -o addopts=""` *(fails: pandas and plotly are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfeea47a608328bc9584188e75af1b