### PR TITLE
Add GitHub Actions workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}/src
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install \
+            pandas==2.3.1 \
+            plotly==6.3.0 \
+            openpyxl==3.1.5 \
+            black==25.1.0 \
+            mypy==1.17.1 \
+            pylint==3.3.8 \
+            pytest==8.4.1 \
+            pytest-cov==6.2.1
+
+      - name: Run Black (format check)
+        run: black --check .
+
+      - name: Run Pylint
+        run: pylint src tests main.py update_task_dates.py
+
+      - name: Run Mypy
+        run: mypy src
+
+      - name: Run Pytest
+        run: pytest

--- a/update_task_dates.py
+++ b/update_task_dates.py
@@ -32,7 +32,9 @@ def build_parser() -> argparse.ArgumentParser:
         default="burnup_history.db",
         help="Path to the SQLite database file (default: burnup_history.db).",
     )
-    parser.add_argument("--project", required=True, help="Project name that owns the task.")
+    parser.add_argument(
+        "--project", required=True, help="Project name that owns the task."
+    )
     parser.add_argument("--task", required=True, help="Task name to update.")
     parser.add_argument(
         "--start-date",


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs black, pylint, mypy, and pytest
- configure the workflow to expose the src package layout through PYTHONPATH for linting and tests

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68cff5c04d908328848dd1ee48c19d63