### PR TITLE
Fix mypy configuration and annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,8 @@ jobs:
     - name: Run Pylint
       run: pylint src tests main.py update_task_dates.py
 
+    - name: Run Mypy
+      run: mypy src
+
     - name: Run Pytest
       run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ max-branches = 15
 max-statements = 60
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -64,6 +64,10 @@ warn_unused_ignores = true
 warn_no_return = true
 warn_unreachable = true
 strict_equality = true
+
+[[tool.mypy.overrides]]
+module = ["pandas", "pandas.*", "plotly", "plotly.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/burnup_system.py
+++ b/src/burnup_system.py
@@ -1,8 +1,10 @@
 """Final fixed burn-up system with proper plan progress filtering."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import plotly.graph_objects as go
 
@@ -11,6 +13,9 @@ from src.data_filter import DataFilter
 from src.data_loader import DataLoader
 from src.database_model import DatabaseModel, ProgressRecord
 from src.progress_calculator import ProgressCalculator
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @dataclass(frozen=True)
@@ -366,7 +371,9 @@ class BurnUpSystem:
                 f"{filter_options.start_date} to {filter_options.end_date}"
             )
 
-    def _apply_chart_filters(self, df, filter_options: DateFilterOptions):
+    def _apply_chart_filters(
+        self, df: "pd.DataFrame", filter_options: DateFilterOptions
+    ) -> "pd.DataFrame":
         """Apply the requested filters and return the filtered DataFrame."""
 
         original_count = len(df)
@@ -402,7 +409,7 @@ class BurnUpSystem:
 
     def _build_chart_components(
         self,
-        project_data,
+        project_data: "pd.DataFrame",
         project_name: str,
         filter_options: DateFilterOptions,
     ) -> ChartComponents:


### PR DESCRIPTION
## Summary
- update the mypy configuration to target Python 3.12 and ignore missing type stubs for pandas and plotly
- add typing-only pandas import and annotate internal filtering helpers in `BurnUpSystem`

## Testing
- `poetry run mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68d0021e4f9c8328b728b7969a8002ae